### PR TITLE
Beta-3-HUD: HUD UI 통합 및 게임 로직 실시간 피드백 연동

### DIFF
--- a/lib/components/chest.dart
+++ b/lib/components/chest.dart
@@ -4,12 +4,29 @@ import 'package:under_dig/mixins/destructible.dart';
 import 'package:under_dig/systems/grid_system.dart';
 import 'package:under_dig/components/grid_entity.dart';
 
+import 'package:under_dig/game.dart';
+import 'package:under_dig/drop/drop_manager.dart';
+
 class Chest extends GridEntity with Destructible {
   late RectangleComponent _visual;
 
   Chest({required super.gridX, required super.gridY, int hp = 1})
     : super(size: Vector2.all(GridSystem.tileSize * 0.8)) {
     initDestructible(hp);
+  }
+
+  @override
+  void onDeath() {
+    print("Chest Opened! Found loot.");
+    final game = findGame()! as MyGame;
+    final item = DropManager().dropItem(game.scoreEngine.stageProgress);
+    final success = game.inventory.addItem(item);
+    if (success) {
+      print('Added ${item.name} to inventory');
+    } else {
+      print('Inventory full!');
+    }
+    super.onDeath();
   }
 
   @override
@@ -37,12 +54,5 @@ class Chest extends GridEntity with Destructible {
 
     // HP Indicator (Optional for Chest? Maybe just hit to open)
     addHpIndicator();
-  }
-
-  @override
-  void onDeath() {
-    print("Chest Opened! Found loot.");
-    // TODO: Drop Item
-    super.onDeath();
   }
 }

--- a/lib/components/enemy.dart
+++ b/lib/components/enemy.dart
@@ -21,6 +21,15 @@ class Enemy extends GridEntity with Destructible {
 
   int attackPower;
 
+  @override
+  void onDeath() {
+    final game = findGame()! as MyGame;
+    game.scoreEngine.onKill();
+    game.scoreEngine.onComboIncrement();
+    game.comboTracker.increment();
+    super.onDeath();
+  }
+
   void onStep() {
     if (!isMounted) return;
     final game = findGame()! as MyGame;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'game.dart';
 import 'ui/lobby_overlay.dart';
 import 'ui/settings_overlay.dart';
 import 'ui/result_overlay.dart';
+import 'ui/hud_overlay.dart';
 
 void main() {
   runApp(
@@ -13,6 +14,7 @@ void main() {
         'Lobby': (context, game) => LobbyOverlay(game: game),
         'Settings': (context, game) => SettingsOverlay(game: game),
         'Result': (context, game) => ResultOverlay(game: game),
+        'HUD': (context, game) => HudOverlay(game: game),
       },
       initialActiveOverlays: const ['Lobby'],
     ),

--- a/lib/managers/level_manager.dart
+++ b/lib/managers/level_manager.dart
@@ -2,6 +2,7 @@ import 'package:flame/components.dart';
 import 'package:flutter/material.dart';
 import 'package:under_dig/game/spawn_controller.dart';
 import 'package:under_dig/systems/grid_system.dart';
+import 'package:under_dig/game.dart';
 
 class LevelManager extends Component {
   int _stageProgress = 0;
@@ -19,6 +20,9 @@ class LevelManager extends Component {
   void advanceStage() {
     _stageProgress++;
     _spawnController.updateStage(_stageProgress);
+    final game = findGame()! as MyGame;
+    game.scoreEngine.onStageAdvance();
+
     // TODO: Trigger UI update or animations for stage advancement
     print('Advanced to Stage: $_stageProgress');
     print('Current Difficulty: ${_spawnController.curve.enemyRate}');

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import '../game.dart';
+
+class HudOverlay extends StatelessWidget {
+  final MyGame game;
+
+  const HudOverlay({super.key, required this.game});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Top Bar: Stats
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              _buildStat('HP', '${game.player.hp}', color: Colors.red),
+              _buildStat(
+                'STAGE',
+                '${game.scoreEngine.stageProgress}',
+                color: Colors.blue,
+              ),
+              _buildStat(
+                'SCORE',
+                '${game.scoreEngine.total}',
+                color: Colors.amber,
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          // Combo
+          if (game.comboTracker.combo > 1)
+            Row(
+              children: [
+                Text(
+                  '${game.comboTracker.combo} COMBO!',
+                  style: const TextStyle(
+                    fontSize: 24,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.orange,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                SizedBox(
+                  width: 100,
+                  child: LinearProgressIndicator(
+                    value: (game.comboTracker.timeLeftMs / 3000).clamp(
+                      0.0,
+                      1.0,
+                    ),
+                    backgroundColor: Colors.white24,
+                    color: Colors.orange,
+                  ),
+                ),
+              ],
+            ),
+          const Spacer(),
+          // Bottom Bar: Inventory
+          Row(
+            children: List.generate(game.inventory.maxSlots, (index) {
+              final item = game.inventory.slots[index];
+              return Container(
+                width: 50,
+                height: 50,
+                margin: const EdgeInsets.only(right: 8),
+                decoration: BoxDecoration(
+                  color: Colors.black54,
+                  border: Border.all(color: Colors.white24),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: item != null
+                    ? Tooltip(
+                        message: '${item.name}\n${item.description}',
+                        child: const Center(
+                          child: Icon(
+                            Icons.star, // Simplified icon for now
+                            color: Colors.white,
+                          ),
+                        ),
+                      )
+                    : null,
+              );
+            }),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStat(String label, String value, {required Color color}) {
+    return Column(
+      children: [
+        Text(
+          label,
+          style: TextStyle(color: color.withOpacity(0.7), fontSize: 12),
+        ),
+        Text(
+          value,
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## 요약
게임 플레이 중 실시간으로 상태(HP, 점수, 스테이지, 콤보, 인벤토리)를 확인할 수 있는 HUD(Heads-Up Display) UI를 통합하고, 실제 게임 로직과의 연동을 완료했습니다.

## 상세 구현 내용
1. **HUD 오버레이 구현 (lib/ui/hud_overlay.dart)**
   - **체력(HP)**: 하트 아이콘 또는 텍스트로 현재 생명력 표시.
   - **진행도**: 현재 스테이지 및 누적 점수 실시간 갱신.
   - **콤보 트래커**: 2콤보 이상 시 콤보 횟수 및 남은 유지 시간을 프로그레스 바로 시각화.
   - **인벤토리**: 현재 보유 중인 아이템 슬롯(5칸) 표시 및 툴팁 연동.

2. **게임 엔진 통합 (lib/game.dart)**
   - `ScoreEngine`, `ComboTracker`, `Inventory`, `BuffManager`를 `MyGame`에 주입하여 중앙 집중식 상태 관리를 구축했습니다.
   - 게임 시작 시 `HUD` 오버레이가 활성화되고, 사망 시 비활성화되도록 흐름을 제어했습니다.

3. **이벤트 피드백 연동**
   - **Enemy**: 적 처치 시(`onDeath`) 점수 가산 및 콤보 카운트 증가 로직 연결.
   - **Chest**: 상자 개봉 시 아이템이 생성되어 인벤토리에 자동으로 추가되는 로직 연결.
   - **LevelManager**: 스테이지 진행 시 점수 엔진에 단계 업 정보를 전달하도록 수정.

4. **메인 진입점 수정 (lib/main.dart)**
   - `HUD` 오버레이를 `overlayBuilderMap`에 등록하여 Flame 엔진에서 접근 가능하게 했습니다.

## 테스트 결과
- 게임 플레이 중 적을 처치하면 점수와 콤보 카운트가 즉시 HUD에 반영됨을 확인했습니다.
- 상자를 열면 인벤토리 슬롯에 아이템이 추가되는 것을 확인했습니다.
- 콤보 유지 시간이 끝나면 HUD의 콤보 표시가 정상적으로 사라짐을 확인했습니다.

## 향후 계획
- 인벤토리의 아이템을 클릭하여 실제로 효과(HP 회복 등)를 발동시키는 기능을 UI와 연결할 예정입니다.
- 콤보 수치에 따른 타격감 있는 애니메이션 효과를 추가할 예정입니다.