### PR TITLE
fix(balance): 궁수 스폰 비활성화 및 물약 스폰 확률 상향

### DIFF
--- a/lib/game.dart
+++ b/lib/game.dart
@@ -162,10 +162,8 @@ class MyGame extends FlameGame with HasKeyboardHandlerComponents, PanDetector {
         double roll = random.nextDouble();
         if (roll < 0.1) {
           spawnGolem(x, 0);
-        } else if (roll < 0.2) {
-          spawnPotion(x, 0); // 10% chance for potion
-        } else if (roll < 0.4) {
-          spawnArcher(x, 0); // 20% chance for archer
+        } else if (roll < 0.25) {
+          spawnPotion(x, 0); // Increase potion chance slightly
         } else {
           spawnEnemy(x, 0, hp: random.nextInt(3) + 1);
         }


### PR DESCRIPTION
## 요약
플레이 난이도 조절 및 게임 메커니즘의 명확성을 위해 궁수(Archer) 캐릭터의 스폰을 일시적으로 비활성화하고 전체적인 몬스터 스폰 밸런스를 조정했습니다.

## 상세 수정 내용
1. **궁수 스폰 비활성화 (`lib/game.dart`)**
   - `spawnEnemyAtTop()` 로직에서 궁수(Archer)가 생성되던 확률 구간을 제거했습니다.
   - 이제 필드 상단에서 궁수가 더 이상 스폰되지 않습니다.

2. **스폰 밸런스 조정**
   - 궁수가 빠진 자리를 메우기 위해 **물약(Potion)**의 스폰 확률을 기존 10%에서 **15%**로 상향 조정했습니다.
   - 나머지 75%는 일반 적(Enemy), 10%는 골렘(Golem)이 차지하도록 재설계했습니다.

## 테스트 결과
- 여러 차례 게임을 실행하여 필드에 더 이상 주황색(궁수) 캐릭터가 등장하지 않음을 확인했습니다.
- 물약 오브젝트가 이전보다 더 자주 등장하여 플레이어의 생존성이 향상된 것을 검증했습니다.

## 향후 계획
- 궁수의 공격 방식(투사체 속도, 사거리 등)을 직관적으로 리팩토링한 후, 특정 스테이지 이상에서만 등장하도록 재도입할 예정입니다.