### PR TITLE
fix(ui): HUD 점수 및 스테이지 실시간 업데이트 미반영 문제 수정

### DIFF
--- a/lib/score/score_engine.dart
+++ b/lib/score/score_engine.dart
@@ -1,5 +1,5 @@
-// Score engine for Under Dig
 import 'dart:math' as math;
+import 'package:flutter/foundation.dart';
 
 enum ScoreEvent { StageAdvance, Kill, Combo }
 
@@ -18,7 +18,7 @@ class ScoreConfig {
   });
 }
 
-class ScoreEngine {
+class ScoreEngine extends ChangeNotifier {
   final ScoreConfig config;
   int _total = 0;
   int stageProgress = 0;
@@ -33,12 +33,14 @@ class ScoreEngine {
   void onStageAdvance() {
     stageProgress += 1;
     _total += _stageProgressPoints(stageProgress);
+    notifyListeners();
   }
 
   int onKill() {
     kills += 1;
     int delta = config.killPoints;
     _total += delta;
+    notifyListeners();
     return delta;
   }
 
@@ -46,12 +48,14 @@ class ScoreEngine {
     combo += 1;
     int delta = _comboBonus(combo);
     _total += delta;
+    notifyListeners();
     return delta;
   }
 
   int onComboReset() {
     int prev = combo;
     combo = 0;
+    notifyListeners();
     return prev;
   }
 
@@ -92,5 +96,6 @@ class ScoreEngine {
     stageProgress = 0;
     kills = 0;
     combo = 0;
+    notifyListeners();
   }
 }

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -1,13 +1,35 @@
 import 'package:flutter/material.dart';
 import '../game.dart';
 
-class HudOverlay extends StatelessWidget {
+class HudOverlay extends StatefulWidget {
   final MyGame game;
 
   const HudOverlay({super.key, required this.game});
 
   @override
+  State<HudOverlay> createState() => _HudOverlayState();
+}
+
+class _HudOverlayState extends State<HudOverlay> {
+  @override
+  void initState() {
+    super.initState();
+    widget.game.scoreEngine.addListener(_update);
+  }
+
+  @override
+  void dispose() {
+    widget.game.scoreEngine.removeListener(_update);
+    super.dispose();
+  }
+
+  void _update() {
+    if (mounted) setState(() {});
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final game = widget.game;
     return Padding(
       padding: const EdgeInsets.all(16.0),
       child: Column(


### PR DESCRIPTION
## 요약
게임 플레이 중 HUD에 표시되는 점수(Score)와 스테이지(Stage) 정보가 실시간으로 갱신되지 않던 문제를 수정했습니다.

## 상세 수정 내용
1. **점수 엔진에 옵저버 패턴 적용 (`lib/score/score_engine.dart`)**
   - `ScoreEngine` 클래스에 `ChangeNotifier`를 믹스인으로 추가했습니다.
   - 점수 획득(`onKill`), 스테이지 진행(`onStageAdvance`), 콤보 증가(`onComboIncrement`) 등 데이터가 변경될 때마다 `notifyListeners()`를 호출하도록 로직을 보강했습니다.

2. **HUD 오버레이 반응형 전환 (`lib/ui/hud_overlay.dart`)**
   - 기존 `StatelessWidget`이었던 `HudOverlay`를 `StatefulWidget`으로 변경했습니다.
   - `initState`에서 `ScoreEngine`의 리스너를 등록하고, 데이터 변경 시 `setState()`를 호출하여 화면이 즉시 다시 그려지도록 수정했습니다.

## 테스트 결과
- 적을 처치하거나 다음 스테이지로 넘어갈 때, HUD 상단의 점수와 스테이지 텍스트가 즉각적으로 업데이트되는 것을 확인했습니다.

## 향후 계획
- 콤보 트래커(`ComboTracker`)와 인벤토리(`Inventory`) 시스템에도 동일한 알림 메커니즘을 적용하여 UI 일관성을 확보할 예정입니다.