### PR TITLE
Beta-3: 게임 화면 레이아웃 구조화 및 HUD 고도화

### DIFF
--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -30,104 +30,202 @@ class _HudOverlayState extends State<HudOverlay> {
   @override
   Widget build(BuildContext context) {
     final game = widget.game;
-    return Padding(
-      padding: const EdgeInsets.all(16.0),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+    return Material(
+      color: Colors.transparent,
+      child: Stack(
         children: [
-          // Top Bar: Stats
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              _buildStat('HP', '${game.player.hp}', color: Colors.red),
-              _buildStat(
-                'STAGE',
-                '${game.scoreEngine.stageProgress}',
-                color: Colors.blue,
-              ),
-              _buildStat(
-                'SCORE',
-                '${game.scoreEngine.total}',
-                color: Colors.amber,
-              ),
-            ],
-          ),
-          const SizedBox(height: 10),
-          // Combo
-          if (game.comboTracker.combo > 1)
-            Row(
-              children: [
-                Text(
-                  '${game.comboTracker.combo} COMBO!',
-                  style: const TextStyle(
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.orange,
-                  ),
+          // Header Area
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 40),
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [Colors.black.withOpacity(0.8), Colors.transparent],
                 ),
-                const SizedBox(width: 10),
-                SizedBox(
-                  width: 100,
-                  child: LinearProgressIndicator(
-                    value: (game.comboTracker.timeLeftMs / 3000).clamp(
-                      0.0,
-                      1.0,
-                    ),
-                    backgroundColor: Colors.white24,
-                    color: Colors.orange,
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  _buildStatCard(
+                    'HP',
+                    '${game.player.hp}',
+                    Colors.redAccent,
+                    Icons.favorite,
                   ),
-                ),
-              ],
+                  _buildStatCard(
+                    'STAGE',
+                    '${game.scoreEngine.stageProgress}',
+                    Colors.blueAccent,
+                    Icons.layers,
+                  ),
+                  _buildStatCard(
+                    'SCORE',
+                    '${game.scoreEngine.total}',
+                    Colors.amber,
+                    Icons.monetization_on,
+                  ),
+                ],
+              ),
             ),
-          const Spacer(),
-          // Bottom Bar: Inventory
-          Row(
-            children: List.generate(game.inventory.maxSlots, (index) {
-              final item = game.inventory.slots[index];
-              return Container(
-                width: 50,
-                height: 50,
-                margin: const EdgeInsets.only(right: 8),
-                decoration: BoxDecoration(
-                  color: Colors.black54,
-                  border: Border.all(color: Colors.white24),
-                  borderRadius: BorderRadius.circular(8),
+          ),
+
+          // Middle Area: Combo Notification
+          if (game.comboTracker.combo > 1)
+            Align(
+              alignment: const Alignment(0, -0.4), // Slightly above center
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    '${game.comboTracker.combo} COMBO!',
+                    style: TextStyle(
+                      fontSize: 40,
+                      fontWeight: FontWeight.w900,
+                      color: Colors.orange,
+                      fontStyle: FontStyle.italic,
+                      shadows: [
+                        Shadow(
+                          color: Colors.black.withOpacity(0.5),
+                          offset: const Offset(2, 2),
+                          blurRadius: 4,
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  SizedBox(
+                    width: 150,
+                    height: 8,
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(4),
+                      child: LinearProgressIndicator(
+                        value: (game.comboTracker.timeLeftMs / 3000).clamp(
+                          0.0,
+                          1.0,
+                        ),
+                        backgroundColor: Colors.black,
+                        valueColor: const AlwaysStoppedAnimation<Color>(
+                          Colors.orange,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+
+          // Footer Area: Inventory
+          Positioned(
+            bottom: 0,
+            left: 0,
+            right: 0,
+            child: Container(
+              padding: const EdgeInsets.fromLTRB(20, 40, 20, 40),
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.bottomCenter,
+                  end: Alignment.topCenter,
+                  colors: [Colors.black.withOpacity(0.9), Colors.transparent],
                 ),
-                child: item != null
-                    ? Tooltip(
-                        message: '${item.name}\n${item.description}',
-                        child: const Center(
-                          child: Icon(
-                            Icons.star, // Simplified icon for now
-                            color: Colors.white,
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Text(
+                    'INVENTORY',
+                    style: TextStyle(
+                      color: Colors.white54,
+                      fontSize: 12,
+                      letterSpacing: 2,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: List.generate(game.inventory.maxSlots, (index) {
+                      final item = game.inventory.slots[index];
+                      return Container(
+                        width: 54,
+                        height: 54,
+                        margin: const EdgeInsets.symmetric(horizontal: 4),
+                        decoration: BoxDecoration(
+                          color: Colors.white.withOpacity(0.1),
+                          borderRadius: BorderRadius.circular(12),
+                          border: Border.all(
+                            color: item != null
+                                ? Colors.white70
+                                : Colors.white10,
+                            width: 1.5,
                           ),
                         ),
-                      )
-                    : null,
-              );
-            }),
+                        child: item != null
+                            ? IconButton(
+                                icon: const Icon(
+                                  Icons.star,
+                                  color: Colors.white,
+                                ),
+                                onPressed: () {
+                                  // TODO: Use item logic
+                                },
+                              )
+                            : null,
+                      );
+                    }),
+                  ),
+                ],
+              ),
+            ),
           ),
         ],
       ),
     );
   }
 
-  Widget _buildStat(String label, String value, {required Color color}) {
-    return Column(
-      children: [
-        Text(
-          label,
-          style: TextStyle(color: color.withOpacity(0.7), fontSize: 12),
-        ),
-        Text(
-          value,
-          style: const TextStyle(
-            color: Colors.white,
-            fontSize: 20,
-            fontWeight: FontWeight.bold,
+  Widget _buildStatCard(
+    String label,
+    String value,
+    Color color,
+    IconData icon,
+  ) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: Colors.white.withOpacity(0.05),
+        borderRadius: BorderRadius.circular(15),
+      ),
+      child: Column(
+        children: [
+          Row(
+            children: [
+              Icon(icon, size: 14, color: color),
+              const SizedBox(width: 4),
+              Text(
+                label,
+                style: TextStyle(
+                  color: color.withOpacity(0.8),
+                  fontSize: 10,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ],
           ),
-        ),
-      ],
+          const SizedBox(height: 2),
+          Text(
+            value,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+              letterSpacing: 1,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## 요약
화면을 상단(Header), 중앙(Play Area), 하단(Footer)으로 분리하여 시각적 안정감을 확보하고, 게임 보드를 정중앙에 배치했습니다.

## 상세 구현 내용
1. **Header 영역 (상단)**:
   - 반투명 그라데이션 배경 위에 HP, STAGE, SCORE를 카드 형태로 배치하여 시인성을 높였습니다.
   - 각 스탯에 아이콘을 추가하여 직관적인 이해를 돕습니다.
2. **Play Area (중앙)**:
   -  로직을 개선하여 8x8 게임 보드가 상/하단 UI 간섭 없이 화면 정중앙에 위치하도록 조정했습니다.
   - 콤보 알림 UI를 보드 약간 위쪽으로 배치하여 액션의 몰입감을 유지했습니다.
3. **Footer 영역 (하단)**:
   - 인벤토리 슬롯을 하단 중앙에 배치하고 세련된 테두리 디자인을 적용했습니다.
   - 향후 액션 카드가 들어갈 공간을 확보했습니다.

## 테스트 결과
- 기기 해상도에 상관없이 보드가 정중앙에 위치하며 UI와 겹치지 않음을 확인했습니다.
- 스탯 업데이트 및 콤보 게이지가 개선된 디자인에서 정상 작동함을 검증했습니다.